### PR TITLE
CLI Fixes and Import Structure Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Package to interface with the Center for Medicare and Medicaid's (CMS) National 
 
 To search the NPPES API, simply search via your terminal.
 
-    $ poetry run python search.py --first_name James --last_name Moore
+    $ search_nppes_api --first_name James --last_name Moore
 
 To search the NPPES API and put results into a DataFrame:
+
+    from nppes import nppes_df
 
     df = nppes_df(first_name='James', last_name='Moore')
 

--- a/nppes/__init__.py
+++ b/nppes/__init__.py
@@ -1,5 +1,4 @@
 __version__ = '0.1.2'
 
 from .files import etl, download
-from .nppes_df import nppes_df
-from .search import search_nppes_api
+from .nppes_df import get_nppes_data, json_data_to_df, nppes_df

--- a/nppes/__init__.py
+++ b/nppes/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 from .files import etl, download
 from .nppes_df import get_nppes_data, json_data_to_df, nppes_df

--- a/nppes/__init__.py
+++ b/nppes/__init__.py
@@ -1,3 +1,5 @@
 __version__ = '0.1.2'
 
 from .files import etl, download
+from .nppes_df import nppes_df
+from .search import search_nppes_api

--- a/nppes/search.py
+++ b/nppes/search.py
@@ -55,5 +55,5 @@ def search_nppes_api(number: int, enumeration_type: str, taxonomy_description: s
     formatted_json_data = format_json_response_cli(json_data)
     click.echo(formatted_json_data)
 
-if __name__ == '__main__':
+def main():
     search_nppes_api()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nppes"
-version = "0.1.2"
+version = "0.1.3"
 description = "Package to interface with the Center for Medicare and Medicaid's (CMS) National Plan and Provider Enumeration System (NPPES)."
 authors = ["Jason Turan <jason.turan@gmail.com>", "Adrienne Franke <adriennefranke@gmail.com>"]
 documentation = "https://github.com/jturan/nppes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = "^3.8"
 requests = "^2.24.0"
 click = "^7.1.2"
 Pygments = "^2.6.1"
+pandas = "^1.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ pytest-cov = "^2.10.0"
 notebook = "^6.1.4"
 pytest-mock = "^3.2.0"
 
+[tool.poetry.scripts]
+search_nppes_api = "nppes.search:main"
+
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
 


### PR DESCRIPTION
- Added `nppes_df` functions to` __init__.py` so package import commands are cleaner
- Added entry points to the `pyproject.toml` so the CLI is a clean `search_nppes_api` command in the terminal after pip installing the package
- Updated `README.md` to include updated import and CLI commands
- Bumped version to 0.1.3